### PR TITLE
fix(deps): jsesc@~0.3.x->^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git://github.com/LavaMoat/sourcemap-validator.git"
   },
   "dependencies": {
-    "jsesc": "~0.3.x",
+    "jsesc": "^3.0.2",
     "lodash": "^4.17.21",
     "source-map": "~0.1.x"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@ jake@0.7.x:
     minimatch "0.2.x"
     utilities "0.0.x"
 
-jsesc@~0.3.x:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.3.0.tgz#1bf5ee63b4539fe2e26d0c1e99c240b97a457972"
-  integrity sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 lodash@^4.17.21:
   version "4.17.21"


### PR DESCRIPTION
- fix(deps): Bump `jsesc` from `~0.3.x` to `^3.0.2`

### Related
#### Blocked by
- [x] #1 

#### Blocking
- #5 